### PR TITLE
Fix typos

### DIFF
--- a/appendix-a.html
+++ b/appendix-a.html
@@ -318,8 +318,8 @@ before you moved <em>ext4 .vhdx</em> to a USB disk:</p>
 default=micah
 </code></pre></div>
 
-<p>Press <strong>CTRL-O</strong>, followed by <strong>ENTER</strong>, to save the file,
-and then press <strong>CTRL-X</strong> to exit. Back in your PowerShell
+<p>Press <strong>CTRL</strong>-O, followed by <strong>ENTER</strong>, to save the file,
+and then press <strong>CTRL</strong>-X to exit. Back in your PowerShell
 terminal, shut down WSL by running this command:</p>
 <div class="codehilite"><pre><span></span><code><span class="n">wsl</span> <span class="p">-</span><span class="n">-shutdown</span>
 </code></pre></div>

--- a/chapter-1.html
+++ b/chapter-1.html
@@ -941,7 +941,7 @@ encryption tab to check whether it&rsquo;s enabled; if not, enable it.</p>
 <p>If you see no Device encryption tab, your PC doesn&rsquo;t support device
 encryption, unfortunately. You have a few options. The easiest option is
 to upgrade to the Pro version of Windows, which typically costs about
-\$100, and then use BitLocker. Alternatively, use VeraCrypt.</p>
+$100, and then use BitLocker. Alternatively, use VeraCrypt.</p>
 <h5>VeraCrypt</h5>
 <p>VeraCrypt is free and open source disk encryption software. To begin,
 download VeraCrypt from

--- a/chapter-1.html
+++ b/chapter-1.html
@@ -1009,7 +1009,7 @@ piece of paper kept in a secure location.</p>
 <h4>Linux</h4>
 <p>Linux uses technology called LUKS for disk encryption. You can check the
 Disks program (in most versions of Linux, to open this program, press
-the Windows key, type <strong>disks</strong>, and press [ENTER]{.small}) to see
+the Windows key, type <strong>disks</strong>, and press <strong>ENTER</strong>) to see
 whether your internal disk is encrypted. The program shows you all of
 the disks attached to your computer and allows you to format them (see
 Figure 1-3. If your internal disk has an
@@ -1163,7 +1163,7 @@ the password hint blank.</p>
 <p>Open the Disks app as you did in Exercise 1-1. Select your USB disk in
 the list of disks on the left, then click the menu button and choose
 <strong>Format Disk</strong>. This will delete all of the data on the USB.</p>
-<p>Click the [+]{.symbol_Bold} button to add a new partition and set the
+<p>Click the <strong>+</strong> button to add a new partition and set the
 partition size to the largest option. Name your disk <em>datasets</em>, choose
 <strong>Internal Disk for Use with Linux Systems Only</strong>, and check the box
 <strong>Password Protect Volume (LUKS)</strong>. It will prompt you to enter a

--- a/chapter-10.html
+++ b/chapter-10.html
@@ -723,7 +723,7 @@ list of sites that already have structures, it can load <em>/api/sites</em> on
 the backend, which returns this data in JSON format. If it wants to
 retrieve data in JSON format from a specific table on a specific site,
 it can load
-<em>/api/</em>[\&lt;]<em>site</em>[&gt;]<em>/</em>[\&lt;]<em>table</em>[&gt;].
+<em>/api/&lt;site&gt;/&lt;table&gt;</em>.
 In this case, the Python code uses the <code>sqlite3</code> module to look up this data in the
 SQlite3 database for that BlueLeaks site, and then returns what it finds
 to the frontend.</p>

--- a/chapter-14.html
+++ b/chapter-14.html
@@ -1706,7 +1706,7 @@ Press CTRL+C to quit
 URL
 <em>http://127.0.0.1:5000</em>.
 The web server continued to run until I was ready to quit it by pressing
-<strong>CTRL-C</strong>. I loaded that URL in my web browser to view the web
+<strong>CTRL</strong>-C. I loaded that URL in my web browser to view the web
 app. As I made web requests, my terminal output showed me web service
 logs. For example, when I loaded the home page, my app produced these
 logs:</p>

--- a/chapter-3.html
+++ b/chapter-3.html
@@ -1166,7 +1166,7 @@ files on this disk.</p>
 <p>After mounting your <em>datasets</em> USB disk, open a terminal and change your
 working directory to the disk. In Linux, the path to your disk is
 probably something like
-<em>/media/</em>[\&lt;]{.symbol_Italic}<em>username</em>[&gt;]{.symbol_Italic}<em>/datasets</em>.
+<em>/media/&lt;username&gt;/datasets</em>.
 For example, my username is <em>micah</em>, so I would run this command:</p>
 <div class="codehilite"><pre><span></span><code><span class="nb">cd</span><span class="w"> </span>/media/micah/datasets
 </code></pre></div>

--- a/chapter-4.html
+++ b/chapter-4.html
@@ -1083,7 +1083,7 @@ Choose the following settings for your VPS:</p>
     bandwidth you want. Less powerful machines are cheaper; more
     powerful ones are more expensive. For this exercise, choose a
     relatively cheap option like 1GB of RAM, 1 CPU, 25GB of disk space,
-    and 1TB of bandwidth for \$7 per month.</li>
+    and 1TB of bandwidth for $7 per month.</li>
 <li>For Add Block Storage, you can choose to attach an additional hard
     disk to your droplet. You don&rsquo;t need to do this now, but in the
     future, to work with a large dataset like BlueLeaks, you can add

--- a/chapter-5.html
+++ b/chapter-5.html
@@ -768,7 +768,7 @@ For example, OCCRP, along with the International Consortium of
 Investigative Journalists (ICIJ), was part of a coalition investigating
 the Panama Papers, an offshore tax haven dataset that led to over 40
 stories about corruption. One of those stories implicated a close friend
-of Vladimir Putin who had embezzled \$230 million from Russian
+of Vladimir Putin who had embezzled $230 million from Russian
 taxpayers. Because OCCRP deals with so much data, it developed Aleph as
 an investigation tool to make it easier to track white-collar crime,
 follow the money, and cross-reference various datasets.</p>

--- a/chapter-6.html
+++ b/chapter-6.html
@@ -113,7 +113,7 @@ in the message. Just as you can convert any decimal number (that is, one
 conveyed using 10 digits) into a binary number (conveyed using 2 digits)
 and back, you can convert any binary data into Base64 data (conveyed
 using 64 characters). For example, here&rsquo;s how a PNG image containing a
-1[×]{.symbol}1 transparent pixel looks with each of its 86 bytes of data
+1×1 transparent pixel looks with each of its 86 bytes of data
 represented as binary digits:</p>
 <div class="codehilite"><pre><span></span><code>10001001 01010000 01001110 01000111 00001101 00001010 00011010 00001010 00000000 00000000
 00000000 00001101 01001001 01001000 01000100 01010010 00000000 00000000 00000000 00000001

--- a/chapter-6.html
+++ b/chapter-6.html
@@ -596,7 +596,7 @@ are and when to use them.</p>
 importing email dumps directly in PST format. However, Outlook has some
 downsides. First, it&rsquo;s not free; the cheapest way to get Outlook is to
 buy a Microsoft 365 license, which, at the time of writing, costs around
-\$7 per month or \$70 per year. Second, Outlook is available only for
+$7 per month or $70 per year. Second, Outlook is available only for
 Windows and macOS, not Linux (though Linux users can run Outlook in a
 Windows VM). Still, you might find Outlook useful if you&rsquo;re familiar
 with the program and understand its advanced
@@ -647,7 +647,7 @@ claims that Ukraine is not an independent country, but rather is
 controlled by the US Democratic Party. The quote also includes the false
 claim that in 2016, then Vice President Joe Biden fired Ukraine&rsquo;s
 attorney general for investigating Biden&rsquo;s son Hunter. (In fact, Biden
-leveraged \$1 billion in US aid to persuade Ukraine to oust its top
+leveraged $1 billion in US aid to persuade Ukraine to oust its top
 prosecutor, Viktor Shokin, who refused to investigate corruption from
 powerful Ukrainians. Biden worked in tandem with anti-corruption efforts
 across Europe: European leaders, as well as civil society groups within

--- a/chapter-7.html
+++ b/chapter-7.html
@@ -190,7 +190,7 @@ to enter a Python command.</p>
 <p>Entering <code>print("Hello World!")</code> and pressing <strong>ENTER</strong> should
 immediately run your code, displaying <code>Hello World!</code> on the next line. Exit the interpreter
 and return to the shell by running <code>exit()</code> or pressing
-<strong>CTRL</strong>[-D]{.Character_20_style}.</p>
+<strong>CTRL</strong>-D.</p>
 <p>In the remainder of this book, if my examples include the <code>&gt;&gt;&gt;</code> prompt, that means they&rsquo;re running in
 the Python interpreter. Run the same code in your own interpreter as you
 follow along.</p>
@@ -221,7 +221,7 @@ space, counting files, searching for keywords, and sorting lists. Here&rsquo;s
 how a few basic mathematical operations work in Python:</p>
 <p><strong>Operators</strong></p>
 <p>The arithmetic operators for addition (+), subtraction
-([−]{.listplain_symbol}), multiplication ([×]{.listplain_symbol}), and
+(−), multiplication (×), and
 division (/) are mostly the same in Python: <code>+</code>, <code>-</code>, and <code>/</code>, with an asterisk <code>*</code> for multiplication.</p>
 <p><strong>Variables</strong></p>
 <p>In math, a variable is a placeholder, normally a letter like <em>x</em>.

--- a/chapter-9.html
+++ b/chapter-9.html
@@ -294,8 +294,8 @@ Fighting in the Streets.&rdquo;</p>
 LibreOffice, as well as in other spreadsheet programs, you can find
 specific cells using the Find feature. Press
 <strong>CTRL</strong>-F (or, in macOS,
-[<code>&lt;?ace 1a ?&gt;</code>-F), enter your search term, and
-press }]{.code_symbol-alt<strong>ENTER</strong>. This should search every cell in the spreadsheet
+<strong>&#x2318;</strong>-F), enter your search term, and
+press <strong>ENTER</strong>. This should search every cell in the spreadsheet
 for your term. You can use this method to find a row containing, for
 example, a specific ID number or email address.</p>
 <p>When you close the spreadsheet, don&rsquo;t save your changes. It&rsquo;s good

--- a/chapter-9.html
+++ b/chapter-9.html
@@ -947,7 +947,7 @@ an internet hoax from late May 2020. In fact, I found multiple articles
 debunking this hoax on fact-checking sites, including Snopes,
 PolitiFact, and <em>Reuters</em>, dated a week before the FBI distributed this
 memo. The fake recruitment flyer offers to compensate &ldquo;professional
-anarchists&rdquo; with \$200 per direct action, and includes the text &ldquo;Funded
+anarchists&rdquo; with $200 per direct action, and includes the text &ldquo;Funded
 by George Soros.&rdquo; (Antisemitic right-wing Americans frequently and
 falsely claim that Soros, a Jewish billionaire, funds left-wing
 protesters.) The flyer also included the phone number for a local branch

--- a/introduction.html
+++ b/introduction.html
@@ -257,7 +257,7 @@ analyzed and reported on massive datasets of leaked neo-Nazi chat logs.
 I also discuss my role in developing a public investigation tool for
 such datasets, called DiscordLeaks. This tool aided in a successful
 lawsuit against the organizers of the deadly Unite the Right rally in 2017, resulting in a settlement of
-over \$25 million in damages against the leaders of the American fascist
+over $25 million in damages against the leaders of the American fascist
 movement.</p>
 <p><strong>Appendixes</strong></p>
 <p>Appendix A includes tips for

--- a/src/md/appendix-a/body.md
+++ b/src/md/appendix-a/body.md
@@ -331,8 +331,8 @@ before you moved *ext4 .vhdx* to a USB disk:
 default=micah
 ```
 
-Press **CTRL-O**, followed by **ENTER**, to save the file,
-and then press **CTRL-X** to exit. Back in your PowerShell
+Press **CTRL**-O, followed by **ENTER**, to save the file,
+and then press **CTRL**-X to exit. Back in your PowerShell
 terminal, shut down WSL by running this command:
 
 ```powershell

--- a/src/md/chapter-1/body.md
+++ b/src/md/chapter-1/body.md
@@ -1142,7 +1142,7 @@ piece of paper kept in a secure location.
 
 Linux uses technology called LUKS for disk encryption. You can check the
 Disks program (in most versions of Linux, to open this program, press
-the Windows key, type **disks**, and press [ENTER]{.small}) to see
+the Windows key, type **disks**, and press **ENTER**) to see
 whether your internal disk is encrypted. The program shows you all of
 the disks attached to your computer and allows you to format them (see
 Figure 1-3. If your internal disk has an
@@ -1340,7 +1340,7 @@ Open the Disks app as you did in Exercise 1-1. Select your USB disk in
 the list of disks on the left, then click the menu button and choose
 **Format Disk**. This will delete all of the data on the USB.
 
-Click the [+]{.symbol_Bold} button to add a new partition and set the
+Click the **+** button to add a new partition and set the
 partition size to the largest option. Name your disk *datasets*, choose
 **Internal Disk for Use with Linux Systems Only**, and check the box
 **Password Protect Volume (LUKS)**. It will prompt you to enter a

--- a/src/md/chapter-1/body.md
+++ b/src/md/chapter-1/body.md
@@ -1052,7 +1052,7 @@ encryption tab to check whether it's enabled; if not, enable it.
 If you see no Device encryption tab, your PC doesn't support device
 encryption, unfortunately. You have a few options. The easiest option is
 to upgrade to the Pro version of Windows, which typically costs about
-\$100, and then use BitLocker. Alternatively, use VeraCrypt.
+$100, and then use BitLocker. Alternatively, use VeraCrypt.
 
 
 

--- a/src/md/chapter-10/body.md
+++ b/src/md/chapter-10/body.md
@@ -855,7 +855,7 @@ list of sites that already have structures, it can load */api/sites* on
 the backend, which returns this data in JSON format. If it wants to
 retrieve data in JSON format from a specific table on a specific site,
 it can load
-*/api/*[\<]*site*[\>]*/*[\<]*table*[\>].
+*/api/<site\>/<table\>*.
 In this case, the Python code uses the `sqlite3` module to look up this data in the
 SQlite3 database for that BlueLeaks site, and then returns what it finds
 to the frontend.

--- a/src/md/chapter-14/body.md
+++ b/src/md/chapter-14/body.md
@@ -1918,7 +1918,7 @@ The output said that the Flask web server started and was running at the
 URL
 *http://127.0.0.1:5000*.
 The web server continued to run until I was ready to quit it by pressing
-**CTRL-C**. I loaded that URL in my web browser to view the web
+**CTRL**-C. I loaded that URL in my web browser to view the web
 app. As I made web requests, my terminal output showed me web service
 logs. For example, when I loaded the home page, my app produced these
 logs:

--- a/src/md/chapter-3/body.md
+++ b/src/md/chapter-3/body.md
@@ -1459,7 +1459,7 @@ files on this disk.
 After mounting your *datasets* USB disk, open a terminal and change your
 working directory to the disk. In Linux, the path to your disk is
 probably something like
-*/media/*[\<]{.symbol_Italic}*username*[\>]{.symbol_Italic}*/datasets*.
+*/media/<username\>/datasets*.
 For example, my username is *micah*, so I would run this command:
 
 ```sh

--- a/src/md/chapter-4/body.md
+++ b/src/md/chapter-4/body.md
@@ -1314,7 +1314,7 @@ Choose the following settings for your VPS:
     bandwidth you want. Less powerful machines are cheaper; more
     powerful ones are more expensive. For this exercise, choose a
     relatively cheap option like 1GB of RAM, 1 CPU, 25GB of disk space,
-    and 1TB of bandwidth for \$7 per month.
+    and 1TB of bandwidth for $7 per month.
 3.  For Add Block Storage, you can choose to attach an additional hard
     disk to your droplet. You don't need to do this now, but in the
     future, to work with a large dataset like BlueLeaks, you can add

--- a/src/md/chapter-5/body.md
+++ b/src/md/chapter-5/body.md
@@ -886,7 +886,7 @@ For example, OCCRP, along with the International Consortium of
 Investigative Journalists (ICIJ), was part of a coalition investigating
 the Panama Papers, an offshore tax haven dataset that led to over 40
 stories about corruption. One of those stories implicated a close friend
-of Vladimir Putin who had embezzled \$230 million from Russian
+of Vladimir Putin who had embezzled $230 million from Russian
 taxpayers. Because OCCRP deals with so much data, it developed Aleph as
 an investigation tool to make it easier to track white-collar crime,
 follow the money, and cross-reference various datasets.

--- a/src/md/chapter-6/body.md
+++ b/src/md/chapter-6/body.md
@@ -690,7 +690,7 @@ Unlike Thunderbird, Microsoft's desktop email program, Outlook, supports
 importing email dumps directly in PST format. However, Outlook has some
 downsides. First, it's not free; the cheapest way to get Outlook is to
 buy a Microsoft 365 license, which, at the time of writing, costs around
-\$7 per month or \$70 per year. Second, Outlook is available only for
+$7 per month or $70 per year. Second, Outlook is available only for
 Windows and macOS, not Linux (though Linux users can run Outlook in a
 Windows VM). Still, you might find Outlook useful if you're familiar
 with the program and understand its advanced
@@ -748,7 +748,7 @@ claims that Ukraine is not an independent country, but rather is
 controlled by the US Democratic Party. The quote also includes the false
 claim that in 2016, then Vice President Joe Biden fired Ukraine's
 attorney general for investigating Biden's son Hunter. (In fact, Biden
-leveraged \$1 billion in US aid to persuade Ukraine to oust its top
+leveraged $1 billion in US aid to persuade Ukraine to oust its top
 prosecutor, Viktor Shokin, who refused to investigate corruption from
 powerful Ukrainians. Biden worked in tandem with anti-corruption efforts
 across Europe: European leaders, as well as civil society groups within

--- a/src/md/chapter-6/body.md
+++ b/src/md/chapter-6/body.md
@@ -75,7 +75,7 @@ in the message. Just as you can convert any decimal number (that is, one
 conveyed using 10 digits) into a binary number (conveyed using 2 digits)
 and back, you can convert any binary data into Base64 data (conveyed
 using 64 characters). For example, here's how a PNG image containing a
-1[×]{.symbol}1 transparent pixel looks with each of its 86 bytes of data
+1×1 transparent pixel looks with each of its 86 bytes of data
 represented as binary digits:
 
 ```

--- a/src/md/chapter-7/body.md
+++ b/src/md/chapter-7/body.md
@@ -186,7 +186,7 @@ Hello World!
 Entering `print("Hello World!")` and pressing **ENTER** should
 immediately run your code, displaying `Hello World!` on the next line. Exit the interpreter
 and return to the shell by running `exit()` or pressing
-**CTRL**[-D]{.Character_20_style}.
+**CTRL**-D.
 
 In the remainder of this book, if my examples include the `>>>` prompt, that means they're running in
 the Python interpreter. Run the same code in your own interpreter as you
@@ -231,7 +231,7 @@ how a few basic mathematical operations work in Python:
 **Operators**
 
 The arithmetic operators for addition (+), subtraction
-([−]{.listplain_symbol}), multiplication ([×]{.listplain_symbol}), and
+(−), multiplication (×), and
 division (/) are mostly the same in Python: `+`, `-`, and `/`, with an asterisk `*` for multiplication.
 
 **Variables**

--- a/src/md/chapter-9/body.md
+++ b/src/md/chapter-9/body.md
@@ -238,7 +238,7 @@ I often use graphical spreadsheet programs to search CSVs. In
 LibreOffice, as well as in other spreadsheet programs, you can find
 specific cells using the Find feature. Press
 **CTRL**-F (or, in macOS,
-[`<?ace 1a ?>`{=html}]{.code_symbol-alt}-F), enter your search term, and
+**&#x2318;**-F), enter your search term, and
 press **ENTER**. This should search every cell in the spreadsheet
 for your term. You can use this method to find a row containing, for
 example, a specific ID number or email address.

--- a/src/md/chapter-9/body.md
+++ b/src/md/chapter-9/body.md
@@ -1035,7 +1035,7 @@ an internet hoax from late May 2020. In fact, I found multiple articles
 debunking this hoax on fact-checking sites, including Snopes,
 PolitiFact, and *Reuters*, dated a week before the FBI distributed this
 memo. The fake recruitment flyer offers to compensate "professional
-anarchists" with \$200 per direct action, and includes the text "Funded
+anarchists" with $200 per direct action, and includes the text "Funded
 by George Soros." (Antisemitic right-wing Americans frequently and
 falsely claim that Soros, a Jewish billionaire, funds left-wing
 protesters.) The flyer also included the phone number for a local branch

--- a/src/md/introduction/body.md
+++ b/src/md/introduction/body.md
@@ -243,7 +243,7 @@ analyzed and reported on massive datasets of leaked neo-Nazi chat logs.
 I also discuss my role in developing a public investigation tool for
 such datasets, called DiscordLeaks. This tool aided in a successful
 lawsuit against the organizers of the deadly Unite the Right rally in 2017, resulting in a settlement of
-over \$25 million in damages against the leaders of the American fascist
+over $25 million in damages against the leaders of the American fascist
 movement.
 
 **Appendixes**


### PR DESCRIPTION
Found a few typos.

I noticed the printed version does not appear to contain these typos, and some of them are noted in the `epub-to-md` notes file. So out of curiosity, was the book written in some other format first, and then the epub version converted to markdown/html and then published to the website?

I just noticed this duplicates some of the changes in #2 .
